### PR TITLE
Quote $LDFLAGS and $CFLAGS paths on Windows

### DIFF
--- a/ext/ashton/extconf.rb
+++ b/ext/ashton/extconf.rb
@@ -11,9 +11,9 @@ case RUBY_PLATFORM
     $LDFLAGS <<  " -framework OpenGL"
 
   when /win32|mingw/
-    gl_path = File.expand_path("../vendor/gl", __FILE__).gsub(" ", "\\ ")
-    $LDFLAGS << " -L#{gl_path}/lib"
-    $CFLAGS << " -I#{gl_path}/include"
+    gl_path = File.expand_path("../vendor/gl", __FILE__)
+    $LDFLAGS << %{ -L"#{gl_path}/lib"}
+    $CFLAGS  << %{ -I"#{gl_path}/include"}
     exit unless have_library('opengl32.lib', 'glVertex3d') || have_library('opengl32')
 
     exit unless have_header 'GL/gl.h'


### PR DESCRIPTION
Currently, there is a bug on Windows regarding compiling Ashton with
rake. The problem is that if a full path to Ashton directory contains
spaces (for example, if Ashton's parent directory is "Documents
And Settings"), `rake compile` fails to compile anything.

Fix this by quotting flag paths that are appended to $LDFLAGS and
$CFLAGS variables.

Signed-off-by: Kyrylo Silin kyrylosilin@gmail.com
