### PR TITLE
Fix ashton/ashton.rb on OS X

### DIFF
--- a/lib/ashton.rb
+++ b/lib/ashton.rb
@@ -3,9 +3,9 @@ require 'gosu'
 
 begin
   RUBY_VERSION =~ /(\d+.\d+)/
-  require "ashton/#{$1}/ashton.so"
+  require "ashton/#{$1}/ashton.#{RbConfig::CONFIG['DLEXT']}"
 rescue LoadError
-  require "ashton/ashton.so"
+  require "ashton/ashton.#{RbConfig::CONFIG['DLEXT']}"
 end
 
 module Ashton


### PR DESCRIPTION
The `DLEXT` is not `.so`, but `.bundle` on OS X. No idea why Ruby does not either use `.dll` on Windows, or `.so` on all systems. `.bundle` is not exactly the canonical extension on OS X either.
