### PR TITLE
Fix installing on OSX

### DIFF
--- a/ext/ashton/GLee.h
+++ b/ext/ashton/GLee.h
@@ -757,7 +757,10 @@ GLEE_EXTERN GLboolean _GLEE_SGIX_texture_range;
 #endif
 
 #ifndef GL_ARB_vertex_buffer_object
-	#if !__x86_64__
+	#ifdef __APPLE__
+		typedef long GLintptrARB;
+		typedef long GLsizeiptrARB;
+	#else
 		typedef ptrdiff_t GLintptrARB;
 		typedef ptrdiff_t GLsizeiptrARB;
 	#endif

--- a/ext/ashton/GLee.h
+++ b/ext/ashton/GLee.h
@@ -757,8 +757,10 @@ GLEE_EXTERN GLboolean _GLEE_SGIX_texture_range;
 #endif
 
 #ifndef GL_ARB_vertex_buffer_object
-	typedef ptrdiff_t GLintptrARB;
-	typedef ptrdiff_t GLsizeiptrARB;
+	#if !__x86_64__
+		typedef ptrdiff_t GLintptrARB;
+		typedef ptrdiff_t GLsizeiptrARB;
+	#endif
 #endif
 
 #ifndef GL_ARB_shader_objects


### PR DESCRIPTION
I did some more reading and found a similar issue in SDL itself

http://lists.libsdl.org/pipermail/commits-libsdl.org/2011-September/012828.html
https://twitter.com/elmindreda/status/398479855324372992

It seems as if apple have defined both buffer objects as long
```
typedef long GLintptrARB;
typedef long GLsizeiptrARB;
```

Setting as x64 only resulted in the same error being generated - this does raise a question if this ever worked on osx?